### PR TITLE
fix spelling of Stack Overflow

### DIFF
--- a/_pages/home.md
+++ b/_pages/home.md
@@ -5,7 +5,7 @@ header:
   overlay_color: "#5e616c"
   overlay_image: /assets/images/mm-home-page-feature.jpg
   actions:
-    - label: "Stackoverflow"
+    - label: "Stack Overflow"
       icon: "fab fa-stack-overflow"
       url: "https://stackoverflow.com/questions/tagged/azure-ad-b2c"
     - label: "GitHub"


### PR DESCRIPTION
Stack Overflow is spelled with two words with capital letters on each. This is how [the company spells it on their own site](https://stackoverflow.co/).