### PR TITLE
Update b2c link in _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -105,7 +105,7 @@ author:
       url: "https://woodgrovegroceriesb2cdemo.azurewebsites.net/"
     - label: "Offical docs"
       icon: "fab fa-microsoft"
-      url: "https://azure.microsoft.com/en-us/services/active-directory-b2c/"
+      url: "https://aka.ms/aadb2c"
     - label: "YouTube"
       icon: "fab fa-youtube"
       url: "https://www.youtube.com/results?search_query=azure+ad+b2c"


### PR DESCRIPTION
The original link (https://azure.microsoft.com/en-us/services/active-directory-b2c/) no longer exists as a service page for Microsoft due to the new "external identities" offering replacing B2C.

Updated link to docs overview instead.